### PR TITLE
#5 - Fix error when clicking incorrect answers on mobile devices

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -45,7 +45,14 @@ export const Question = ({ question }: { question: IQuestion }) => {
             <ListItemButton
               disabled={question.userSelectedAnswerIndex != null}
               onClick={createHandleClick(index)}
-              sx={{ bgcolor: getBackgroundColor(question, index) }}
+              sx={{
+                bgcolor: getBackgroundColor(question, index),
+
+                // For mobile: the background color used for incorrect answers is the one from hover
+                ":hover": {
+                  bgcolor: getBackgroundColor(question, index),
+                },
+              }}
             >
               <ListItemText primary={answer} sx={{ textAlign: "center" }} />
             </ListItemButton>


### PR DESCRIPTION
Change the background color on hover when the user selects an answer so the background color on mobile browsers can actually change.